### PR TITLE
Added tests for doctors

### DIFF
--- a/backend/doctors/tests/test_models.py
+++ b/backend/doctors/tests/test_models.py
@@ -1,0 +1,163 @@
+import uuid
+from datetime import date, time
+
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+
+from core.models import BaseModel
+from common.enums import Gender, AcademicDegree, DoctorType, RoomType, Shift
+from common.constants import DOCTOR_LENGTH, COMMON_LENGTH, PATIENT_LENGTH, ENUM_LENGTH, SCHEDULE_DEFAULTS, DECIMAL_MAX_DIGITS, DECIMAL_DECIMAL_PLACES
+from doctors.models import Department, ExaminationRoom, Doctor, Schedule, ScheduleStatus
+
+User = get_user_model()
+
+class DepartmentModelTest(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.department = Department.objects.create(
+            department_name="Khoa Tim mạch",
+            description="Chuyên điều trị các bệnh về tim mạch",
+            avatar="tim_mach.png"
+        )
+
+    def test_department_name_label(self):
+        field_label = self.department._meta.get_field('department_name').verbose_name
+        self.assertEqual(field_label, 'department name')
+
+    def test_department_name_max_length(self):
+        max_length = self.department._meta.get_field('department_name').max_length
+        self.assertEqual(max_length, DOCTOR_LENGTH["DEPARTMENT_NAME"])
+
+    def test_description_label(self):
+        field_label = self.department._meta.get_field('description').verbose_name
+        self.assertEqual(field_label, 'description')
+
+    def test_avatar_label(self):
+        field_label = self.department._meta.get_field('avatar').verbose_name
+        self.assertEqual(field_label, 'avatar')
+
+    def test_string_representation(self):
+        self.assertEqual(str(self.department), "Khoa Tim mạch")
+
+
+class ExaminationRoomModelTest(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.department = Department.objects.create(department_name="Khoa Thần kinh")
+        cls.room = ExaminationRoom.objects.create(
+            department=cls.department,
+            type=RoomType.EXAMINATION.value,
+            building="A",
+            floor=5,
+            note="Phòng khám bệnh nhân"
+        )
+
+    def test_department_label(self):
+        field_label = self.room._meta.get_field('department').verbose_name
+        self.assertEqual(field_label, 'department')
+
+    def test_type_label(self):
+        field_label = self.room._meta.get_field('type').verbose_name
+        self.assertEqual(field_label, 'type')
+
+    def test_building_max_length(self):
+        max_length = self.room._meta.get_field('building').max_length
+        self.assertEqual(max_length, DOCTOR_LENGTH["BUILDING"])
+
+    def test_string_representation(self):
+        expected = f"{self.department.department_name} - {self.room.building} {self.room.floor}"
+        self.assertEqual(str(self.room), expected)
+
+
+class DoctorModelTest(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create(email='bacsinguyen@example.com')
+        cls.department = Department.objects.create(department_name="Khoa Xương khớp")
+        cls.doctor = Doctor.objects.create(
+            user=cls.user,
+            identity_number="094222222222",
+            first_name="Văn",
+            last_name="Nguyễn",
+            birthday=date(1985, 3, 15),
+            gender=Gender.MALE.value,
+            address="Thủ đức, Tp HCM",
+            academic_degree=AcademicDegree.BS.value,
+            specialization="Phẫu thuật xương",
+            type=DoctorType.EXAMINATION.value,
+            department=cls.department,
+            avatar="bac_si_nguyen.png",
+            price=1500000.00
+        )
+
+    def test_first_name_label(self):
+        field_label = self.doctor._meta.get_field('first_name').verbose_name
+        self.assertEqual(field_label, 'first name')
+
+    def test_identity_number_max_length(self):
+        max_length = self.doctor._meta.get_field('identity_number').max_length
+        self.assertEqual(max_length, PATIENT_LENGTH["IDENTITY"])
+
+    def test_price_decimal_places(self):
+        decimal_places = self.doctor._meta.get_field('price').decimal_places
+        self.assertEqual(decimal_places, DECIMAL_DECIMAL_PLACES)
+
+    def test_string_representation(self):
+        expected = f"Dr. {self.doctor.first_name} {self.doctor.last_name}"
+        self.assertEqual(str(self.doctor), expected)
+
+
+class ScheduleModelTest(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create(email='bacsitran@example.com')
+        cls.department = Department.objects.create(department_name="Khoa Nhi")
+        cls.room = ExaminationRoom.objects.create(
+            department=cls.department,
+            type=RoomType.EXAMINATION.value,
+            building="B",
+            floor=3
+        )
+        cls.doctor = Doctor.objects.create(
+            user=cls.user,
+            identity_number="099999999999",
+            first_name="Thị",
+            last_name="Trần",
+            gender=Gender.FEMALE.value,
+            academic_degree=AcademicDegree.BS.value,
+            specialization="Chăm sóc nhi khoa",
+            type=DoctorType.SERVICE.value,
+            department=cls.department
+        )
+        cls.schedule = Schedule.objects.create(
+            doctor=cls.doctor,
+            work_date=date(2025, 8, 27),
+            start_time=time(8, 0),
+            end_time=time(11, 0),
+            shift=Shift.MORNING.value,
+            room=cls.room,
+            max_patients=SCHEDULE_DEFAULTS["MAX_PATIENTS"],
+            current_patients=SCHEDULE_DEFAULTS["CURRENT_PATIENTS"],
+            status=ScheduleStatus.AVAILABLE,
+            default_appointment_duration_minutes=SCHEDULE_DEFAULTS["APPOINTMENT_DURATION_MINUTES"]
+        )
+
+    def test_doctor_label(self):
+        field_label = self.schedule._meta.get_field('doctor').verbose_name
+        self.assertEqual(field_label, 'doctor')
+
+    def test_status_default(self):
+        default_status = self.schedule._meta.get_field('status').default
+        self.assertEqual(default_status, ScheduleStatus.AVAILABLE)
+
+    def test_max_patients_default(self):
+        default_max_patients = self.schedule._meta.get_field('max_patients').default
+        self.assertEqual(default_max_patients, SCHEDULE_DEFAULTS["MAX_PATIENTS"])
+
+    def test_string_representation(self):
+        expected = f"Schedule {self.schedule.doctor} {self.schedule.work_date} {self.schedule.shift}"
+        self.assertEqual(str(self.schedule), expected)

--- a/backend/doctors/tests/test_serializers.py
+++ b/backend/doctors/tests/test_serializers.py
@@ -1,0 +1,372 @@
+from django.test import TestCase
+from django.utils import timezone
+from datetime import date, time
+from rest_framework import serializers
+from doctors.models import Doctor, Department, ExaminationRoom, Schedule
+from doctors.serializers import (
+    DepartmentSerializer, ExaminationRoomSerializer, ScheduleSerializer,
+    CreateDoctorRequestSerializer, DoctorSerializer, DoctorPartialUpdateSerializer,
+    DoctorUpdateSerializer
+)
+from users.models import User
+from common.enums import Gender, AcademicDegree, DoctorType, RoomType, Shift, UserRole
+from common.constants import DOCTOR_LENGTH, COMMON_LENGTH, PATIENT_LENGTH, USER_LENGTH, DECIMAL_MAX_DIGITS, DECIMAL_DECIMAL_PLACES
+
+class DepartmentSerializerTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.department = Department.objects.create(
+            department_name="Cardiology",
+            description="Heart-related treatments",
+            avatar="https://example.com/avatar.jpg"
+        )
+
+    def test_serialize_department(self):
+        serializer = DepartmentSerializer(self.department)
+        expected_data = {
+            'id': self.department.id,
+            'department_name': "Cardiology",
+            'description': "Heart-related treatments",
+            'avatar': "https://example.com/avatar.jpg",
+            'created_at': self.department.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+        }
+        self.assertEqual(serializer.data, expected_data)
+
+    def test_validate_department(self):
+        data = {
+            'department_name': "Neurology",
+            'description': "Brain-related treatments",
+            'avatar': "https://example.com/neuro.jpg"
+        }
+        serializer = DepartmentSerializer(data=data)
+        self.assertTrue(serializer.is_valid())
+        department = serializer.save()
+        self.assertEqual(department.department_name, "Neurology")
+
+class ExaminationRoomSerializerTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.department = Department.objects.create(department_name="Cardiology")
+        cls.room = ExaminationRoom.objects.create(
+            department=cls.department,
+            type=RoomType.EXAMINATION.value,
+            building="A",
+            floor=1,
+            note="Room 101"
+        )
+
+    def test_serialize_examination_room(self):
+        serializer = ExaminationRoomSerializer(self.room)
+        expected_data = {
+            'roomId': self.room.id,
+            'id': self.room.id,
+            'department': self.department.id,
+            'department_id': self.department.id,
+            'type': RoomType.EXAMINATION.value,
+            'building': "A",
+            'floor': 1,
+            'note': "Room 101",
+            'created_at': self.room.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+        }
+        self.assertEqual(serializer.data, expected_data)
+
+    def test_validate_examination_room(self):
+        data = {
+            'department': self.department.id,
+            'type': RoomType.EXAMINATION.value,
+            'building': "B",
+            'floor': 2,
+            'note': "Room 202"
+        }
+        serializer = ExaminationRoomSerializer(data=data)
+        self.assertTrue(serializer.is_valid())
+        room = serializer.save()
+        self.assertEqual(room.building, "B")
+        self.assertEqual(room.floor, 2)
+
+class ScheduleSerializerTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(email='testuser@example.com', password='testpass123')
+        cls.department = Department.objects.create(department_name="Cardiology")
+        cls.doctor = Doctor.objects.create(
+            user=cls.user,
+            first_name="John",
+            last_name="Doe",
+            identity_number="123456789",
+            birthday=date(1980, 1, 1),
+            gender=Gender.MALE.value,
+            academic_degree=AcademicDegree.BS_CKI.value,
+            specialization="Cardiologist",
+            type=DoctorType.EXAMINATION.value,
+            department=cls.department,
+            price=100.00
+        )
+        cls.room = ExaminationRoom.objects.create(
+            department=cls.department,
+            type=RoomType.EXAMINATION.value,
+            building="A",
+            floor=1,
+            note="Room 101"
+        )
+        cls.schedule = Schedule.objects.create(
+            doctor=cls.doctor,
+            room=cls.room,
+            work_date=date(2025, 8, 26),
+            start_time=time(8, 0),
+            end_time=time(12, 0),
+            shift=Shift.MORNING.value,
+            max_patients=10,
+            current_patients=0,
+            status="AVAILABLE",
+            default_appointment_duration_minutes=30
+        )
+
+    def test_serialize_schedule(self):
+        serializer = ScheduleSerializer(self.schedule)
+        expected_data = {
+            'id': self.schedule.id,
+            'work_date': "2025-08-26",
+            'start_time': "08:00:00",
+            'end_time': "12:00:00",
+            'shift': Shift.MORNING.value,
+            'max_patients': 10,
+            'current_patients': 0,
+            'status': "AVAILABLE",
+            'default_appointment_duration_minutes': 30,
+            'created_at': self.schedule.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+            'doctor_id': self.doctor.id,
+            'room_id': self.room.id,
+            'location': f"Tòa A, tầng 1, phòng Room 101",
+            'building': "A",
+            'floor': 1,
+            'room_note': "Room 101"
+        }
+        self.assertEqual(serializer.data, expected_data)
+
+    def test_validate_schedule(self):
+        data = {
+            'doctor': self.doctor.id,
+            'room': self.room.id,
+            'work_date': "2025-08-27",
+            'start_time': "13:00:00",
+            'end_time': "17:00:00",
+            'shift': Shift.AFTERNOON.value,
+            'max_patients': 8,
+            'default_appointment_duration_minutes': 30
+        }
+        serializer = ScheduleSerializer(data=data)
+        self.assertTrue(serializer.is_valid())
+        schedule = serializer.save()
+        self.assertEqual(schedule.work_date, date(2025, 8, 27))
+        self.assertEqual(schedule.shift, Shift.AFTERNOON.value)
+
+    def test_read_only_fields(self):
+        data = {
+            'doctor': self.doctor.id,
+            'room': self.room.id,
+            'work_date': "2025-08-27",
+            'start_time': "13:00:00",
+            'end_time': "17:00:00",
+            'shift': Shift.AFTERNOON.value,
+            'max_patients': 8,
+            'current_patients': 5,  # Should be ignored
+            'status': "FULL",  # Should be ignored
+            'default_appointment_duration_minutes': 30
+        }
+        serializer = ScheduleSerializer(data=data)
+        self.assertTrue(serializer.is_valid())
+        schedule = serializer.save()
+        self.assertEqual(schedule.current_patients, 0)  # Default value
+        self.assertEqual(schedule.status, "AVAILABLE")  # Default value
+
+class CreateDoctorRequestSerializerTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.department = Department.objects.create(department_name="Cardiology")
+
+    def test_valid_data(self):
+        data = {
+            'email': "newdoctor@example.com",
+            'password': "newpass123",
+            'identity_number': "987654321",
+            'first_name': "Jane",
+            'last_name': "Smith",
+            'birthday': "1990-01-01",
+            'gender': Gender.FEMALE.value,
+            'address': "456 Test Ave",
+            'academic_degree': AcademicDegree.BS_CKI.value,
+            'specialization': "Neurologist",
+            'type': DoctorType.EXAMINATION.value,
+            'department_id': self.department.id,
+            'price': 150.00,
+            'avatar': "https://example.com/avatar.jpg"
+        }
+        serializer = CreateDoctorRequestSerializer(data=data)
+        self.assertTrue(serializer.is_valid())
+        self.assertEqual(serializer.validated_data['email'], "newdoctor@example.com")
+
+    def test_missing_required_fields(self):
+        data = {
+            'email': "newdoctor@example.com",
+            # Missing password, identity_number, first_name, last_name, birthday, gender, academic_degree, specialization, type, department_id
+        }
+        serializer = CreateDoctorRequestSerializer(data=data)
+        self.assertFalse(serializer.is_valid())
+        self.assertIn('password', serializer.errors)
+        self.assertIn('identity_number', serializer.errors)
+        self.assertIn('first_name', serializer.errors)
+        self.assertIn('last_name', serializer.errors)
+        self.assertIn('birthday', serializer.errors)
+        self.assertIn('gender', serializer.errors)
+        self.assertIn('academic_degree', serializer.errors)
+        self.assertIn('specialization', serializer.errors)
+        self.assertIn('type', serializer.errors)
+        self.assertIn('department_id', serializer.errors)
+
+    def test_missing_email_and_phone(self):
+        data = {
+            'password': "newpass123",
+            'identity_number': "987654321",
+            'first_name': "Jane",
+            'last_name': "Smith",
+            'birthday': "1990-01-01",
+            'gender': Gender.FEMALE.value,
+            'academic_degree': AcademicDegree.BS_CKI.value,
+            'specialization': "Neurologist",
+            'type': DoctorType.EXAMINATION.value,
+            'department_id': self.department.id
+        }
+        serializer = CreateDoctorRequestSerializer(data=data)
+        self.assertFalse(serializer.is_valid())
+        self.assertIn('email_or_phone', serializer.errors)
+
+class DoctorSerializerTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(
+            email='testuser@example.com',
+            password='testpass123',
+            role=UserRole.DOCTOR.value
+        )
+        cls.department = Department.objects.create(department_name="Cardiology")
+        cls.doctor = Doctor.objects.create(
+            user=cls.user,
+            first_name="John",
+            last_name="Doe",
+            identity_number="123456789",
+            birthday=date(1980, 1, 1),
+            gender=Gender.MALE.value,
+            address="123 Test St",
+            academic_degree=AcademicDegree.BS_CKI.value,
+            specialization="Cardiologist",
+            type=DoctorType.EXAMINATION.value,
+            department=cls.department,
+            price=100.00,
+            avatar="https://example.com/avatar.jpg"
+        )
+
+    def test_serialize_doctor(self):
+        serializer = DoctorSerializer(self.doctor)
+        expected_data = {
+            'id': self.doctor.id,
+            'user': {
+                'id': self.user.id,
+                'created_at': self.user.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                'updated_at': self.user.updated_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                'email': 'testuser@example.com',
+                'password': self.user.password,
+                'phone': None,
+                'role': UserRole.DOCTOR.value,
+                'is_active': True,
+                'is_verified': False,
+                'is_deleted': False,
+                'deleted_at': None
+            },
+            'department': {
+                'id': self.department.id,
+                'department_name': "Cardiology",
+                'description': None,
+                'avatar': None,
+                'created_at': self.department.created_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+            },
+            'created_at': self.doctor.created_at.strftime("%Y-%m-%dT%H:%M:%S"),
+            'schedules': [],
+            'updated_at': self.doctor.updated_at.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+            'identity_number': "123456789",
+            'first_name': "John",
+            'last_name': "Doe",
+            'birthday': "1980-01-01",
+            'gender': Gender.MALE.value,
+            'address': "123 Test St",
+            'academic_degree': AcademicDegree.BS_CKI.value,
+            'specialization': "Cardiologist",
+            'type': DoctorType.EXAMINATION.value,
+            'avatar': "https://example.com/avatar.jpg",
+            'price': "100.00"
+        }
+        self.assertEqual(serializer.data, expected_data)
+
+class DoctorPartialUpdateSerializerTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(email='testuser@example.com', password='testpass123')
+        cls.department = Department.objects.create(department_name="Cardiology")
+        cls.doctor = Doctor.objects.create(
+            user=cls.user,
+            first_name="John",
+            last_name="Doe",
+            identity_number="123456789",
+            birthday=date(1980, 1, 1),
+            gender=Gender.MALE.value,
+            address="123 Test St",
+            academic_degree=AcademicDegree.BS_CKI.value,
+            specialization="Cardiologist",
+            type=DoctorType.EXAMINATION.value,
+            department=cls.department,
+            price=100.00
+        )
+
+    def test_partial_update(self):
+        data = {
+            'first_name': "Updated John",
+            'specialization': "Neurologist"
+        }
+        serializer = DoctorPartialUpdateSerializer(instance=self.doctor, data=data, partial=True)
+        self.assertTrue(serializer.is_valid())
+        updated_doctor = serializer.save()
+        self.assertEqual(updated_doctor.first_name, "Updated John")
+        self.assertEqual(updated_doctor.specialization, "Neurologist")
+        self.assertEqual(updated_doctor.last_name, "Doe")  # Unchanged
+
+    def test_empty_data(self):
+        serializer = DoctorPartialUpdateSerializer(instance=self.doctor, data={}, partial=True)
+        self.assertTrue(serializer.is_valid())  # Empty data is valid for partial updates
+        updated_doctor = serializer.save()
+        self.assertEqual(updated_doctor.first_name, "John")  # No changes
+
+class DoctorUpdateSerializerTest(TestCase):
+    def test_valid_data(self):
+        data = {
+            'first_name': "Jane",
+            'last_name': "Smith",
+            'email': "jane.smith@example.com",
+            'phone': "0123456789"  # Assuming a valid phone format
+        }
+        serializer = DoctorUpdateSerializer(data=data)
+        self.assertTrue(serializer.is_valid())
+        self.assertEqual(serializer.validated_data['first_name'], "Jane")
+        self.assertEqual(serializer.validated_data['email'], "jane.smith@example.com")
+
+    def test_invalid_phone(self):
+        data = {
+            'phone': "invalid_phone"
+        }
+        serializer = DoctorUpdateSerializer(data=data)
+        self.assertFalse(serializer.is_valid())
+        self.assertIn('non_field_errors', serializer.errors)
+
+    def test_empty_data(self):
+        serializer = DoctorUpdateSerializer(data={})
+        self.assertFalse(serializer.is_valid())
+        self.assertIn('non_field_errors', serializer.errors)

--- a/backend/doctors/tests/test_services.py
+++ b/backend/doctors/tests/test_services.py
@@ -1,0 +1,289 @@
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+from datetime import date, time, timedelta
+from unittest.mock import patch
+from doctors.models import Doctor, Department, ExaminationRoom, Schedule
+from doctors.services import DoctorService, DepartmentService, ExaminationRoomService, ScheduleService
+from users.models import User
+from patients.models import Patient
+from common.enums import Gender, AcademicDegree, DoctorType, RoomType, Shift
+from appointments.models import Appointment
+from common.enums import AppointmentStatus
+
+User = get_user_model()
+
+class DoctorServiceTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(email='testuser@example.com', password='testpass123')
+        cls.department = Department.objects.create(department_name='Cardiology')
+        cls.doctor = Doctor.objects.create(
+            user=cls.user,
+            first_name='John',
+            last_name='Doe',
+            identity_number='123456789',
+            birthday=date(1980, 1, 1),
+            gender=Gender.MALE.value,
+            address='123 Test St',
+            academic_degree=AcademicDegree.BS_CKI.value,
+            specialization='Cardiologist',
+            type=DoctorType.EXAMINATION.value,
+            department=cls.department,
+            price=100.00
+        )
+        cls.service = DoctorService()
+
+    def test_get_all_doctors(self):
+        doctors = self.service.get_all_doctors()
+        self.assertEqual(doctors.count(), 1)
+        self.assertEqual(doctors.first().id, self.doctor.id)
+
+    def test_get_doctor_by_id(self):
+        doctor = self.service.get_doctor_by_id(self.doctor.id)
+        self.assertEqual(doctor.id, self.doctor.id)
+
+    def test_create_doctor(self):
+        data = {
+            'email': f'newdoctor{int(timezone.now().timestamp())}@example.com',  # Dynamic email
+            'password': 'newpass123',
+            'first_name': 'Jane',
+            'last_name': 'Smith',
+            'identity_number': '987654321',
+            'birthday': date(1990, 1, 1),
+            'gender': Gender.FEMALE.value,
+            'address': '456 Test Ave',
+            'academic_degree': AcademicDegree.BS_CKI.value,
+            'specialization': 'Neurologist',
+            'type': DoctorType.EXAMINATION.value,
+            'department_id': self.department.id,
+            'price': 150.00
+        }
+        doctor = self.service.create_doctor(data)
+        self.assertEqual(doctor.identity_number, '987654321')
+        self.assertEqual(doctor.user.email, data['email'])
+
+    def test_update_doctor(self):
+        data = {'first_name': 'Updated John'}
+        updated_doctor = self.service.update_doctor(self.doctor.id, data)
+        self.assertEqual(updated_doctor.first_name, 'Updated John')
+
+    def test_delete_doctor(self):
+        self.service.delete_doctor(self.doctor.id)
+        self.assertFalse(Doctor.objects.filter(id=self.doctor.id).exists())
+
+    def test_find_by_identity_number(self):
+        doctor = self.service.find_by_identity_number('123456789')
+        self.assertEqual(doctor.id, self.doctor.id)
+
+    def test_filter_doctors(self):
+        doctors = self.service.filter_doctors(
+            gender=Gender.MALE.value,
+            academic_degree=None,
+            specialization='Cardiologist',
+            type=None
+        )
+        self.assertEqual(doctors.count(), 1)
+        self.assertEqual(doctors.first().id, self.doctor.id)
+
+    def test_get_doctor_by_user_id(self):
+        doctor = self.service.get_doctor_by_user_id(self.user.id)
+        self.assertEqual(doctor.id, self.doctor.id)
+
+    @patch('cloudinary.uploader.upload')
+    def test_upload_avatar(self, mock_upload):
+        mock_upload.return_value = {'secure_url': 'https://test.com/avatar.jpg'}
+        file = 'fake_file'
+        updated_doctor = self.service.upload_avatar(self.doctor, file)
+        self.assertEqual(updated_doctor.avatar, 'https://test.com/avatar.jpg')
+
+    @patch('cloudinary.uploader.destroy')
+    def test_delete_avatar(self, mock_destroy):
+        self.doctor.avatar = 'https://test.com/avatar.jpg'
+        self.doctor.save()
+        updated_doctor = self.service.delete_avatar(self.doctor)
+        self.assertIsNone(updated_doctor.avatar)
+
+class DepartmentServiceTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.department = Department.objects.create(department_name='Neurology')
+        cls.service = DepartmentService()
+
+    def test_get_all_departments(self):
+        departments = self.service.get_all_departments()
+        self.assertEqual(departments.count(), 1)
+        self.assertEqual(departments.first().id, self.department.id)
+
+    def test_get_department_by_id(self):
+        department = self.service.get_department_by_id(self.department.id)
+        self.assertEqual(department.id, self.department.id)
+
+    def test_create_department(self):
+        data = {'department_name': 'Orthopedics'}
+        department = self.service.create_department(data)
+        self.assertEqual(department.department_name, 'Orthopedics')
+
+    def test_update_department(self):
+        data = {'department_name': 'Updated Neurology'}
+        updated_department = self.service.update_department(self.department.id, data)
+        self.assertEqual(updated_department.department_name, 'Updated Neurology')
+
+    def test_delete_department(self):
+        self.service.delete_department(self.department.id)
+        self.assertFalse(Department.objects.filter(id=self.department.id).exists())
+
+    def test_get_doctors_by_department_id(self):
+        doctors = self.service.get_doctors_by_department_id(self.department.id)
+        self.assertEqual(doctors.count(), 0)  # No doctors in this department
+
+class ExaminationRoomServiceTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.department = Department.objects.create(department_name='Neurology')
+        cls.room = ExaminationRoom.objects.create(
+            department=cls.department,
+            type=RoomType.EXAMINATION.value,
+            building='A',
+            floor=1
+        )
+        cls.service = ExaminationRoomService()
+
+    def test_get_all_examination_rooms(self):
+        rooms = self.service.get_all_examination_rooms()
+        self.assertEqual(rooms.count(), 1)
+        self.assertEqual(rooms.first().id, self.room.id)
+
+    def test_get_examination_room_by_id(self):
+        room = self.service.get_examination_room_by_id(self.room.id)
+        self.assertEqual(room.id, self.room.id)
+
+    def test_create_examination_room(self):
+        data = {
+            'department': self.department,
+            'type': RoomType.EXAMINATION.value,
+            'building': 'B',
+            'floor': 2
+        }
+        room = self.service.create_examination_room(data)
+        self.assertEqual(room.building, 'B')
+
+    def test_update_examination_room(self):
+        data = {'building': 'Updated A'}
+        updated_room = self.service.update_examination_room(self.room.id, data)
+        self.assertEqual(updated_room.building, 'Updated A')
+
+    def test_delete_examination_room(self):
+        self.service.delete_examination_room(self.room.id)
+        self.assertFalse(ExaminationRoom.objects.filter(id=self.room.id).exists())
+
+    def test_filter_rooms(self):
+        rooms = self.service.filter_rooms(type=RoomType.EXAMINATION.value, building='A', floor=1)
+        self.assertEqual(rooms.count(), 1)
+        self.assertEqual(rooms.first().id, self.room.id)
+
+class ScheduleServiceTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(email='testuser@example.com', password='testpass123')
+        cls.department = Department.objects.create(department_name='Cardiology')
+        cls.doctor = Doctor.objects.create(
+            user=cls.user,
+            first_name='John',
+            last_name='Doe',
+            identity_number='123456789',
+            birthday=date(1980, 1, 1),
+            gender=Gender.MALE.value,
+            address='123 Test St',
+            academic_degree=AcademicDegree.BS_CKI.value,
+            specialization='Cardiologist',
+            type=DoctorType.EXAMINATION.value,
+            department=cls.department,
+            price=100.00
+        )
+        cls.room = ExaminationRoom.objects.create(
+            department=cls.department,
+            type=RoomType.EXAMINATION.value,
+            building='A',
+            floor=1
+        )
+        cls.schedule = Schedule.objects.create(
+            doctor=cls.doctor,
+            room=cls.room,
+            shift=Shift.MORNING.value,
+            work_date=date(2025, 8, 26),
+            start_time=time(8, 0),
+            end_time=time(12, 0),
+            max_patients=10,
+            default_appointment_duration_minutes=30
+        )
+        cls.service = ScheduleService()
+
+    def test_get_all_schedules(self):
+        schedules = self.service.get_all_schedules(doctor_id=self.doctor.id, shift=Shift.MORNING.value, work_date=date(2025, 8, 26), room_id=self.room.id)
+        self.assertEqual(schedules.count(), 1)
+        self.assertEqual(schedules.first().id, self.schedule.id)
+
+    def test_get_schedule_by_id(self):
+        schedule = self.service.get_schedule_by_id(self.schedule.id)
+        self.assertEqual(schedule.id, self.schedule.id)
+
+    def test_create_schedule(self):
+        data = {
+            'room': self.room,
+            'shift': Shift.AFTERNOON.value,
+            'work_date': date(2025, 8, 27),
+            'start_time': time(13, 0),
+            'end_time': time(17, 0),
+            'max_patients': 10,
+            'default_appointment_duration_minutes': 30
+        }
+        schedule = self.service.create_schedule(doctor_id=self.doctor.id, data=data)
+        self.assertEqual(schedule.shift, Shift.AFTERNOON.value)
+
+    def test_update_schedule(self):
+        data = {'shift': Shift.AFTERNOON.value}
+        updated_schedule = self.service.update_schedule(self.doctor.id, self.schedule.id, data)
+        self.assertEqual(updated_schedule.shift, Shift.AFTERNOON.value)
+
+    def test_delete_schedule(self):
+        self.service.delete_schedule(self.doctor.id, self.schedule.id)
+        self.assertFalse(Schedule.objects.filter(id=self.schedule.id).exists())
+
+    def test_get_all_schedules_for_admin(self):
+        schedules = self.service.get_all_schedules_for_admin()
+        self.assertEqual(schedules.count(), 1)
+        self.assertEqual(schedules.first().id, self.schedule.id)
+
+    def test_get_schedules_by_ids(self):
+        schedules = self.service.get_schedules_by_ids([self.schedule.id])
+        self.assertEqual(schedules.count(), 1)
+        self.assertEqual(schedules.first().id, self.schedule.id)
+
+    def test_update_current_patients_count(self):
+        # Create a user for the patient
+        patient_user = User.objects.create_user(
+            email=f'patient{int(timezone.now().timestamp())}@example.com',
+            password='patientpass123'
+        )
+        # Create a patient with required fields
+        patient = Patient.objects.create(
+            user=patient_user,
+            first_name='Test',
+            last_name='Patient',
+            identity_number='111222333',
+            insurance_number='INS123456',
+            birthday=date(1990, 1, 1),
+            gender=Gender.FEMALE.value
+        )
+        # Create an appointment
+        Appointment.objects.create(
+            schedule=self.schedule,
+            doctor=self.doctor,
+            patient=patient,
+            slot_start=timezone.now(),
+            slot_end=timezone.now() + timedelta(minutes=30),
+            status=AppointmentStatus.CONFIRMED.value
+        )
+        updated_schedule = self.service.update_current_patients_count(self.schedule.id)
+        self.assertEqual(updated_schedule.current_patients, 1)

--- a/backend/doctors/tests/test_views.py
+++ b/backend/doctors/tests/test_views.py
@@ -1,0 +1,279 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from rest_framework import status
+from django.contrib.auth import get_user_model
+from datetime import date, time
+from common.enums import DoctorType, AcademicDegree, Gender, RoomType, Shift
+from doctors.models import Doctor, Department, ExaminationRoom, Schedule
+from doctors.serializers import DoctorSerializer, DepartmentSerializer, ExaminationRoomSerializer, ScheduleSerializer
+
+User = get_user_model()
+
+class DoctorViewSetTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(email='testuser@example.com', password='testpass123')
+        cls.department = Department.objects.create(department_name='Cardiology')
+        cls.doctor = Doctor.objects.create(
+            user=cls.user,
+            first_name='John',
+            last_name='Doe',
+            identity_number='123456789',
+            birthday=date(1980, 1, 1),
+            gender=Gender.MALE.value,
+            address='123 Test St',
+            academic_degree=AcademicDegree.BS_CKII.value,
+            specialization='Cardiologist',
+            type=DoctorType.EXAMINATION.value,
+            department=cls.department,
+            price=100.00
+        )
+
+    def test_list_doctors(self):
+        response = self.client.get(reverse('doctor-list'))
+        doctors = Doctor.objects.all()
+        serializer = DoctorSerializer(doctors, many=True)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, serializer.data)
+
+    def test_retrieve_doctor(self):
+        response = self.client.get(reverse('doctor-detail', kwargs={'pk': self.doctor.pk}))
+        serializer = DoctorSerializer(self.doctor)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, serializer.data)
+
+    def test_create_doctor_authenticated(self):
+        self.client.force_authenticate(user=self.user)
+        data = {
+            'password': 'newpass123',
+            'email': 'newuser@example.com',
+            'first_name': 'Jane',
+            'last_name': 'Smith',
+            'identity_number': '094521111111',
+            'birthday': '1990-01-01',
+            'gender': Gender.FEMALE.value,
+            'address': '456 Test Ave',
+            'academic_degree': AcademicDegree.BS.value,
+            'specialization': 'Neurologist',
+            'type': DoctorType.SERVICE.value,
+            'department_id': self.department.id,
+            'price': 150.00
+        }
+        response = self.client.post(reverse('doctor-list'), data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(Doctor.objects.filter(identity_number='094521111111').exists())
+
+    def test_update_doctor_authenticated(self):
+        self.client.force_authenticate(user=self.user)
+        data = {
+            'first_name': 'John',
+            'last_name': 'Smith',
+            'identity_number': '094555555555',
+            'birthday': '1980-01-01',
+            'gender': Gender.MALE.value,
+            'address': '789 Test Rd',
+            'academic_degree': AcademicDegree.BS.value,
+            'specialization': 'Cardiologist',
+            'type': DoctorType.SERVICE.value,
+            'department_id': self.department.id,
+            'price': 200.00
+        }
+        response = self.client.patch(reverse('doctor-detail', kwargs={'pk': self.doctor.pk}), data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.doctor.refresh_from_db()
+        self.assertEqual(self.doctor.address, '789 Test Rd')
+
+    def test_partial_update_doctor_authenticated(self):
+        self.client.force_authenticate(user=self.user)
+        data = {'address': '999 New St', 'price': 250.00}
+        response = self.client.patch(reverse('doctor-detail', kwargs={'pk': self.doctor.pk}), data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.doctor.refresh_from_db()
+        self.assertEqual(self.doctor.address, '999 New St')
+        self.assertEqual(self.doctor.price, 250.00)
+
+    def test_destroy_doctor_authenticated(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.delete(reverse('doctor-detail', kwargs={'pk': self.doctor.pk}))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(Doctor.objects.filter(pk=self.doctor.pk).exists())
+
+    def test_search_doctor_by_identity_number(self):
+        response = self.client.get(reverse('doctor-search') + '?identityNumber=123456789')
+        serializer = DoctorSerializer(self.doctor)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, serializer.data)
+
+    def test_filter_doctors(self):
+        response = self.client.get(reverse('doctor-filter') + '?specialization=Cardiologist')
+        doctors = Doctor.objects.filter(specialization='Cardiologist')
+        serializer = DoctorSerializer(doctors, many=True)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, serializer.data)
+
+class DepartmentViewSetTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(email='testuser@example.com', password='testpass123')
+        cls.department = Department.objects.create(department_name='Neurology')
+
+    def test_list_departments(self):
+        response = self.client.get(reverse('department-list'))
+        departments = Department.objects.all()
+        serializer = DepartmentSerializer(departments, many=True)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, serializer.data)
+
+    def test_retrieve_department(self):
+        response = self.client.get(reverse('department-detail', kwargs={'pk': self.department.pk}))
+        serializer = DepartmentSerializer(self.department)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, serializer.data)
+
+    def test_create_department_authenticated(self):
+        self.client.force_authenticate(user=self.user)
+        data = {'department_name': 'Orthopedics'}
+        response = self.client.post(reverse('department-list'), data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(Department.objects.filter(department_name='Orthopedics').exists())
+
+    def test_update_department_authenticated(self):
+        self.client.force_authenticate(user=self.user)
+        data = {'department_name': 'Neurology Updated'}
+        response = self.client.put(reverse('department-detail', kwargs={'pk': self.department.pk}), data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.department.refresh_from_db()
+        self.assertEqual(self.department.department_name, 'Neurology Updated')
+
+    def test_destroy_department_authenticated(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.delete(reverse('department-detail', kwargs={'pk': self.department.pk}))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(Department.objects.filter(pk=self.department.pk).exists())
+
+    def test_get_doctors_by_department(self):
+        response = self.client.get(reverse('department-doctors', kwargs={'pk': self.department.pk}))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, [])
+
+class ExaminationRoomViewSetTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(email='testuser@example.com', password='testpass123')
+        cls.department = Department.objects.create(department_name='Neurology')
+        cls.room = ExaminationRoom.objects.create(
+            department=cls.department,
+            type=RoomType.EXAMINATION.value,
+            building='A',
+            floor=1
+        )
+
+    def test_list_rooms(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(reverse('examination-room-list'))
+        rooms = ExaminationRoom.objects.all()
+        serializer = ExaminationRoomSerializer(rooms, many=True)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, serializer.data)
+
+    def test_retrieve_room(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(reverse('examination-room-detail', kwargs={'pk': self.room.pk}))
+        serializer = ExaminationRoomSerializer(self.room)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, serializer.data)
+
+    def test_create_room_authenticated(self):
+        self.client.force_authenticate(user=self.user)
+        data = {
+            'department': self.department.id,
+            'type': RoomType.EXAMINATION.value,
+            'building': 'B',
+            'floor': 2
+        }
+        response = self.client.post(reverse('examination-room-list'), data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(ExaminationRoom.objects.filter(building='B', floor=2).exists())
+
+    def test_search_rooms(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(reverse('examination-room-search') + '?type=E')
+        rooms = ExaminationRoom.objects.filter(type=RoomType.EXAMINATION.value)
+        serializer = ExaminationRoomSerializer(rooms, many=True)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, serializer.data)
+
+class ScheduleViewSetTest(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(email='testuser@example.com', password='testpass123')
+        cls.department = Department.objects.create(department_name='Cardiology')
+        cls.doctor = Doctor.objects.create(
+            user=cls.user,
+            first_name='John',
+            last_name='Doe',
+            identity_number='123456789',
+            birthday=date(1980, 1, 1),
+            gender=Gender.MALE.value,
+            address='123 Test St',
+            academic_degree=AcademicDegree.BS_CKII.value,
+            specialization='Cardiologist',
+            type=DoctorType.SERVICE.value,
+            department=cls.department,
+            price=100.00
+        )
+        cls.room = ExaminationRoom.objects.create(
+            department=cls.department,
+            type=RoomType.EXAMINATION.value,
+            building='A',
+            floor=1
+        )
+        cls.schedule = Schedule.objects.create(
+            doctor=cls.doctor,
+            room=cls.room,
+            shift=Shift.MORNING.value,
+            work_date=date(2025, 8, 26),
+            start_time=time(8, 0),
+            end_time=time(12, 0),
+            max_patients=10,
+            default_appointment_duration_minutes=30
+        )
+
+    def test_list_schedules(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(reverse('schedule-list'))
+        schedules = Schedule.objects.all()
+        serializer = ScheduleSerializer(schedules, many=True)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, serializer.data)
+
+    def test_retrieve_schedule(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(reverse('schedule-detail', kwargs={'pk': self.schedule.pk}))
+        serializer = ScheduleSerializer(self.schedule)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, serializer.data)
+
+    def test_create_schedule_authenticated(self):
+        self.client.force_authenticate(user=self.user)
+        data = {
+            'doctor': self.doctor.id,
+            'room': self.room.id,
+            'shift': Shift.AFTERNOON.value,
+            'work_date': '2025-08-27',
+            'start_time': '13:00',
+            'end_time': '17:00',
+            'max_patients': 10,
+            'default_appointment_duration_minutes': 30
+        }
+        response = self.client.post(reverse('schedule-list'), data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(Schedule.objects.filter(shift=Shift.AFTERNOON.value, work_date='2025-08-27').exists())
+
+    def test_get_schedules_by_date(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(reverse('schedule-get-by-date', kwargs={'date': '2025-08-26'}))
+        schedules = Schedule.objects.filter(work_date=date(2025, 8, 26))
+        serializer = ScheduleSerializer(schedules, many=True)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, serializer.data)


### PR DESCRIPTION
## Checklist tự review pull trước khi ready để trainer review
- [x] Sử dụng thụt lề 2 spaces/4 spaces đồng nhất ở tất cả các files (setting lại vscode /sublime text/ ... nếu chưa cài đặt)
- [x] Cuối mỗi file kiểm tra có end line (khi đẩy lên git xem file change không bị lỗi tròn đỏ ở cuối file)
- [x] Mỗi dòng nếu quá dài, cần xuống dòng (maximum: 80 kí tự mỗi dòng, setting trong IDE)
- [x] gitignore các file chứa thông tin nhạy cảm (VD: .env, ..), file .pyc (python cache), ...
- [x] Tham khảo Python coding convention https://peps.python.org/pep-0008/
- [x] Kiểm tra mỗi pull request chỉ 1 commit, nếu nhiều hơn 1 commit thì hãy gộp commit thành 1 rồi đẩy lại lên git
- [x] Install [PEP8](https://pypi.org/project/pep8/) ở local để check và fix các lỗi liên quan đến syntax, coding convention. Khi gửi thì chụp ảnh PASS đính kèm trong pull
- [x] Nếu làm việc nhóm trong project thì mỗi pull cần **ít nhất 1 APPROVED** từ thành viên trong nhóm

## Related Tickets
- [ticket redmine link](https://edu-redmine.sun-asterisk.vn/issues/92175)

## HOW
- Nhóm em xin phép chạy lệnh test với `--keepdb` bởi vì Neon dùng pgbouncer để quản lý pool connection, nên lệnh test bình thường sẽ báo lỗi khi tự động xóa test db ạ

## Evidence (Screenshot or Video)
- Test models:
<img width="914" height="289" alt="image" src="https://github.com/user-attachments/assets/21d807a9-d26d-4b9c-96e2-9d4dfa818c9d" />

- Test serializers:
<img width="889" height="297" alt="image" src="https://github.com/user-attachments/assets/7e519795-edab-4807-8c35-e94d256fb5e6" />

- Test services:
<img width="911" height="275" alt="image" src="https://github.com/user-attachments/assets/759607fd-8180-46e8-807e-2342553a3881" />

- Test views:
<img width="888" height="276" alt="image" src="https://github.com/user-attachments/assets/025a792c-655f-48dd-b6d9-6e684b702db6" />

## Notes (Kiến thức tìm hiểu thêm)
